### PR TITLE
prevent adding methods to the functions `>` and `!=`

### DIFF
--- a/src/Point3D.jl
+++ b/src/Point3D.jl
@@ -97,9 +97,7 @@ function Base.isapprox(p1::Point3D, p2::Point3D; atol=1e-6, kwargs...)
 end
 
 isless(p1::Point3D, p2::Point3D)          = (p1.x < p2.x) && (p1.y < p2.y) && (p1.z < p2.z)
-!=(p1::Point3D, p2::Point3D)              = !isequal(p1, p2)
 <(p1::Point3D, p2::Point3D)               = isless(p1,p2)
->(p1::Point3D, p2::Point3D)               = p2 < p1
 ==(p1::Point3D, p2::Point3D)              = isequal(p1, p2)
 
 """


### PR DESCRIPTION
As documented, the intended way to implement `>` is to add a method to `<`. A package should never add a method to `>`.

Adding a method to `!=` may make sense in rare cases, but not in this one.